### PR TITLE
add og:description based on same text from h2 paragraph

### DIFF
--- a/index-es.html
+++ b/index-es.html
@@ -5,6 +5,7 @@
     </title>
     <meta charSet="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta property="og:description" content="LibreTaxi se libera del intermediario entre pasajeros y conductores, haciendo mas econmico el taxi. Puedes negociar el precio del viaje antes de confirmarlo y paga en efectivo al llegar. 1-minuto para emplear a los conductores." />
     <link rel="stylesheet" type="text/css" href="css/main.css">
     <link rel="stylesheet" type="text/css" href="css/devices.css">
   </head>

--- a/index-id.html
+++ b/index-id.html
@@ -5,6 +5,7 @@
     </title>
     <meta charSet="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta property="og:description" content="LibreTaxi membuat taksi menjadi lebih terjangkau dengan cara menyingkirkan pihak ketiga di antara penumpang dan pengemudi. Lakukan negosiasi harga sebelum perjalanan dibuat dan bayar secara tunai ketika sampai di tujuan. Pendaftaran hanya dalam waktu 1 menit untuk semua pengemudi." />
     <link rel="stylesheet" type="text/css" href="css/main.css">
     <link rel="stylesheet" type="text/css" href="css/devices.css">
   </head>

--- a/index-pt.html
+++ b/index-pt.html
@@ -5,6 +5,7 @@
     </title>
     <meta charSet="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta property="og:description" content="LibreTaxi faz o uso de táxis ou carros de aluguel mais acessível, por se livrar da parte intermediária entre passageiros e motoristas. Negocie o valor antes da corrida e pague em dinheiro ao chegar. Tudo resolvido em menos de 1 minuto." />
     <link rel="stylesheet" type="text/css" href="css/main.css">
     <link rel="stylesheet" type="text/css" href="css/devices.css">
   </head>

--- a/index-ru.html
+++ b/index-ru.html
@@ -5,6 +5,7 @@
     </title>
     <meta charSet="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta property="og:description" content="LibreTaxi делает такси снова доступным, убирая слой корпораций из цепочки водитель-пассажир. Пассажиры платят наличными и связываются с водителями напрямую. LibreTaxi выполняет роль легкого связующего звена, позволяя договориться о цене поездки. Без регистраций, меньше ограничений." />
     <link rel="stylesheet" type="text/css" href="css/main.css">
     <link rel="stylesheet" type="text/css" href="css/devices.css">
   </head>

--- a/index-tr.html
+++ b/index-tr.html
@@ -5,6 +5,7 @@
     </title>
     <meta charSet="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta property="og:description" content="LibreTaxi, yolcular ile sürücüler arasındaki üçüncü şahısları çıkararak taksi ücretlerini daha uygun hale getirir. Sürüş onaylanmadan önce ücret pazarlığı yapın, gideceğiniz yere vardığınızda nakit ödeyin. Herşey 1 dakikada tamamlanır." />
     <link rel="stylesheet" type="text/css" href="css/main.css">
     <link rel="stylesheet" type="text/css" href="css/devices.css">
   </head>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     </title>
     <meta charSet="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta property="og:description" content="LibreTaxi makes taxi affordable by getting rid of the third party between passengers and drivers. Negotiate the price before the ride is confirmed, pay cash upon arrival. 1-minute hiring for all drivers." />
     <link rel="stylesheet" type="text/css" href="css/main.css">
     <link rel="stylesheet" type="text/css" href="css/devices.css">
   </head>


### PR DESCRIPTION
I haven't tested this out, but according to https://developers.facebook.com/docs/sharing/webmasters#markup this is the proper way to add open graph meta tags.  To verify it is correct after you update the website, simply visit: https://developers.facebook.com/tools/debug/og/object/?q=http%3A%2F%2Flibretaxi.org%2F and check the description.

Note I didn't add the tags for ogoa and industan index files because the h2 paragraph text seemed still still be in russian.