### PR TITLE
"ridesharing" instead of "taxi"

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
             Free and open source alternative to Uber/Lyft connecting passengers and drivers.
           </h1>
           <h2 class="paragraph ">
-            LibreTaxi makes taxi affordable by getting rid of the third party between passengers and drivers. Negotiate the price before the ride is confirmed, pay cash upon arrival. 1-minute hiring for all drivers.
+            LibreTaxi makes ridesharing affordable by getting rid of the third party between passengers and drivers. Negotiate the price before the ride is confirmed, pay cash upon arrival. 1-minute hiring for all drivers.
           </h2>
           <div class="ctas">
             <a class="ctas-button" href="https://telegram.me/libretaxi_bot">


### PR DESCRIPTION
The phrase: "LibreTaxi makes taxi afforable" has a grammatical problem, because taxi is being used as a noun.  But taxi as a noun refers to the actual physical taxicab.  To convert the verb "taxi" into a noun, you would need to use it's present participle "taxi-ing" but I don't think that such a present participle construction even makes sense.  Rather, I suggest you use the commonly understood term "ridesharing" which google reports as the correct present participle for the verb "ride-share", which is a more precise term, and also avoids redundancy, since you are already calling the service "LibreTaxi".